### PR TITLE
Vpd 1027 fix failure of Mdc.preservingMdc() to preserve mdc

### DIFF
--- a/src/main/scala/uk/gov/hmrc/mdc/Mdc.scala
+++ b/src/main/scala/uk/gov/hmrc/mdc/Mdc.scala
@@ -27,14 +27,14 @@ trait Mdc {
     Option(MDC.getCopyOfContextMap).fold(Map.empty[String, String])(_.asScala.toMap)
 
   def withMdc[A](block: => Future[A], mdcData: Map[String, String])(implicit ec: ExecutionContext): Future[A] =
-    block.map { a =>
+    block.transform({ a =>
       putMdc(mdcData)
       a
-    }.recoverWith {
-      case t =>
+    }, {
+      t =>
         putMdc(mdcData)
-        Future.failed(t)
-    }
+        t
+    })
 
   def putMdc(mdc: Map[String, String]): Unit =
     mdc.foreach {

--- a/src/test/scala/uk/gov/hmrc/mdc/MdcSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/mdc/MdcSpec.scala
@@ -49,20 +49,20 @@ class MdcSpec
 
   "Preserving MDC" should {
     "show that MDC is lost when switching contexts" in {
-      (for {
-        _ <- Future.successful(org.slf4j.MDC.put("k", "v"))
-        _ <- runActionWhichLosesMdc()
-      } yield
-        Option(MDC.get("k"))
+      (Future.successful(org.slf4j.MDC.put("k", "v"))
+        .flatMap(_ =>
+          runActionWhichLosesMdc()
+            .map(_ => Option(MDC.get("k")))
+        )
       ).futureValue shouldBe None
     }
 
     "restore MDC" in {
-      (for {
-         _ <- Future.successful(org.slf4j.MDC.put("k", "v"))
-         _ <- Mdc.preservingMdc(runActionWhichLosesMdc())
-       } yield
-        Option(MDC.get("k"))
+      (Future.successful(org.slf4j.MDC.put("k", "v"))
+        .flatMap(_ =>
+          Mdc.preservingMdc(runActionWhichLosesMdc())
+            .map(_ => Option(MDC.get("k")))
+        )
       ).futureValue shouldBe Some("v")
     }
 

--- a/src/test/scala/uk/gov/hmrc/mdc/MdcSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/mdc/MdcSpec.scala
@@ -28,10 +28,10 @@ import scala.concurrent.{ExecutionContext, ExecutionContextExecutorService, Futu
 
 class MdcSpec
   extends AnyWordSpec
-     with Matchers
-     with ScalaFutures
-     with IntegrationPatience
-     with BeforeAndAfter {
+    with Matchers
+    with ScalaFutures
+    with IntegrationPatience
+    with BeforeAndAfter {
 
   before {
     MDC.clear()
@@ -49,31 +49,28 @@ class MdcSpec
 
   "Preserving MDC" should {
     "show that MDC is lost when switching contexts" in {
-      (Future.successful(org.slf4j.MDC.put("k", "v"))
-        .flatMap(_ =>
-          runActionWhichLosesMdc()
-            .map(_ => Option(MDC.get("k")))
-        )
-      ).futureValue shouldBe None
+      org.slf4j.MDC.put("k", "v")
+
+      runActionWhichLosesMdc()
+        .map(_ => Option(MDC.get("k")))
+        .futureValue shouldBe None
     }
 
     "restore MDC" in {
-      (Future.successful(org.slf4j.MDC.put("k", "v"))
-        .flatMap(_ =>
-          Mdc.preservingMdc(runActionWhichLosesMdc())
-            .map(_ => Option(MDC.get("k")))
-        )
-      ).futureValue shouldBe Some("v")
+      org.slf4j.MDC.put("k", "v")
+
+      Mdc.preservingMdc(runActionWhichLosesMdc())
+        .map(_ => Option(MDC.get("k")))
+        .futureValue shouldBe Some("v")
     }
 
     "restore MDC when exception is thrown" in {
-      (for {
-         _ <- Future.successful(org.slf4j.MDC.put("k", "v"))
-         _ <- Mdc.preservingMdc(runActionWhichLosesMdc(fail = true))
-       } yield None
-      ).recover { case _ =>
-        Option(MDC.get("k"))
-      }.futureValue shouldBe Some("v")
+      org.slf4j.MDC.put("k", "v")
+
+      Mdc.preservingMdc(runActionWhichLosesMdc(fail = true))
+        .recover { case _ =>
+          Option(MDC.get("k"))
+        }.futureValue shouldBe Some("v")
     }
   }
 

--- a/src/test/scala/uk/gov/hmrc/mdc/RequestMdcSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/mdc/RequestMdcSpec.scala
@@ -93,7 +93,7 @@ class RequestMdcSpec
         (1 to length).map(_ => chars(random.nextInt(chars.length))).mkString
       }
 
-      val numEntries = 20000
+      val numEntries = 100000
       for (requestId <- 1 to numEntries)
         RequestMdc.add(requestId.toLong, Map("k" -> randomString(1000)))
       // we're still here, so no OOM


### PR DESCRIPTION
This change makes evident, and then fixes, a thread-scheduling problem that can intermittently cause `Mdc.preservingMdc()` to fail to preserve MDC when using an `ExecutionContext` that does not also preserve MDC.

In particular, this will fix the intermittent failures of `SessionRepositorySpec` seen by frontend micro-services created from the scaffold up until 2025/10/14 when [this PR](https://github.com/hmrc/hmrc-frontend-scaffold.g8/pull/141) was merged which addressed the issue by changing the `ExecutionContext` used by the test.

By addressing the fundamental problem in this PR, the flakey `SessionRepositorySpec` will be fixed for all existing services suffering from the problem once they pull through the change as an update to bootstrap.

In brief, the issue stems from `Mdc.preservingMdc()` making 2 transformations, one with `map()` and another with `recoverWith()`. Each of these are executed on a thread chosen by the thread scheduler from the `ExecutionContext`. Both transformations are preformed irrespective of whether the Future is successful or fails, though the `map()` has no effect if failed, and the `recoverWith()` has no effect if successful. While `putMdc()` is used in each of these cases inside their respective bodies, it is the fact that the other transformation is also executed but does not preserve MDC that causes the issue. Using the `transform()` function to combine these 2 steps into one eliminates this problem; whether the Future is successful or failed, it only performs 1 transformation and that uses `putMdc()`. The problem and fix are detailed closely in the individual commit messages, should further details be required.